### PR TITLE
DO NOT MERGE -- add new features, support recent emacs

### DIFF
--- a/org-mime.el
+++ b/org-mime.el
@@ -644,15 +644,19 @@ The cursor is left in the TO field."
 	     ;; exposed depending on the backend.
 	     (org-body (prog1
 			   (with-current-buffer org-buf
-			     (format "#+BEGIN_EXPORT org\n%s\n#+END_EXPORT"
-				     (buffer-string)))
+			     ;; (format "#+BEGIN_EXPORT org\n%s\n#+END_EXPORT"
+				   ;;   (buffer-string))
+           (buffer-string))
 			 (kill-buffer org-buf)))
 	     (html-body (prog1
 			    (with-current-buffer html-buf
 			      (format "#+BEGIN_EXPORT html\n%s\n#+END_EXPORT"
-				      (buffer-string)))
+				      (buffer-string))
+            ;; (buffer-string)
+            )
 			  (kill-buffer html-buf)))
-	     (body (concat org-body "\n" html-body)))
+	     ;; (body (concat org-body "\n" html-body))
+       (body org-body))
 	(save-restriction
 	  (org-narrow-to-subtree)
 	  (org-mime-compose body file to subject other-headers

--- a/org-mime.el
+++ b/org-mime.el
@@ -585,6 +585,12 @@ The cursor ends in the TO field."
 	 ;;  	     (buffer-string)))
 	 ;;   (kill-buffer buf)))
    (body (buffer-string)))
+    (if (eq org-mime-library 'mu4e)
+        (advice-add 'mu4e~switch-back-to-mu4e-buffer :after
+                    `(lambda ()
+                       (switch-to-buffer (get-buffer ,(buffer-name) ))
+                       (advice-remove 'mu4e~switch-back-to-mu4e-buffer "om-temp-advice"))
+                    '((name . "om-temp-advice"))))
     (org-mime-compose body file to subject other-headers
 		      (or org-mime-export-options
 			  (when (fboundp 'org-export--get-inbuffer-options)
@@ -666,6 +672,12 @@ The cursor is left in the TO field."
 	  (org-narrow-to-subtree)
 	  (org-mime-compose body file to subject other-headers
 			    (or org-mime-export-options subtree-opts)))
+        (if (eq org-mime-library 'mu4e)
+        (advice-add 'mu4e~switch-back-to-mu4e-buffer :after
+                    `(lambda ()
+                       (switch-to-buffer (get-buffer ,(buffer-name) ))
+                       (advice-remove 'mu4e~switch-back-to-mu4e-buffer "om-temp-advice"))
+                    '((name . "om-temp-advice"))))
 	(message-goto-to)))))
 
 (provide 'org-mime)

--- a/org-mime.el
+++ b/org-mime.el
@@ -572,14 +572,15 @@ The cursor ends in the TO field."
 			 (cc `((cc . ,cc)))
 			 (bcc `((bcc . ,bcc)))
 			 (t nil)))
-	 (buf (org-html-export-as-html
-	       nil nil nil t (or org-mime-export-options
-				 (org-export--get-inbuffer-options))))
-         (body (prog1
-		   (with-current-buffer buf
-		     (format "#+BEGIN_EXPORT html\n%s\n#+END_EXPORT"
-			     (buffer-string)))
-		 (kill-buffer buf))))
+	 ;; (buf (org-html-export-as-html
+	 ;;       nil nil nil t (or org-mime-export-options
+	 ;;  		 (org-export--get-inbuffer-options))))
+   ;; (body (prog1
+	 ;;     (with-current-buffer buf
+	 ;;       (format "#+BEGIN_EXPORT html\n%s\n#+END_EXPORT"
+	 ;;  	     (buffer-string)))
+	 ;;   (kill-buffer buf)))
+   (body (buffer-string)))
     (org-mime-compose body file to subject other-headers
 		      (or org-mime-export-options
 			  (when (fboundp 'org-export--get-inbuffer-options)

--- a/org-mime.el
+++ b/org-mime.el
@@ -424,7 +424,8 @@ If ARG is not nil, use `org-mime-fixedwith-wrap' to wrap the exported text."
          (html-and-images
           (org-mime-replace-images
            (org-mime--export-string header-body
-                                    'html
+                                    ;;'html
+                                    'htmlmail
                                     (if (fboundp 'org-export--get-inbuffer-options)
                                         (org-export--get-inbuffer-options)))
            tmp-file))


### PR DESCRIPTION
Hi @redguardtoo , 

I wasn't able to get org-mime to work for me so I rebased off of john kitchin's old pull request from a while ago.  I don't think my work is ready to be merged (at all!) and I am not able to test with older versions of org and emacs. However, I wanted to show you the new features I've added:

- support for mu4e as an email library
- initial support for exporting some plain text paragraphs starting with "> " as blockquotes. This needs to be improved, probably with a recursive function to allow for multiple levels of blockquotes, and probably also to remove the ">" characters from the front of the lines.  

Please let me know what you think if you have a chance.