### PR TITLE
Use compose-mail, rather than explicitly using message-mail

### DIFF
--- a/org-mime.el
+++ b/org-mime.el
@@ -465,8 +465,7 @@ If SUBTREEP is t, curret org node is subtree."
          (plain (cdr exported))
          (export-opts (org-mime-get-export-options subtreep))
          patched-html)
-    (unless (featurep 'message) (require 'message))
-    (message-mail to subject headers nil)
+    (compose-mail to subject headers nil)
     (message-goto-body)
     (setq patched-html (with-temp-buffer
                          (insert html)


### PR DESCRIPTION
By using `message-mail` directly, my emails open in `message-mode`, rather than `mu4e-compose-mode`. This is annoying, because it means that I don't get my `mu4e` contact completion.

I tried opening `emacs -Q` and running `compose-mail` works properly by default, opening up a `message-mode` buffer, so I don't think it's necessary to `(require 'message)` before calling `compose-mail`.

I'm not sure about the `(message-goto-body)`, but it works fine for `mu4e` because it derives from `message-mode`. It might be that other modes don't work the same way, and so the call to `(message-goto-body)` needs to be different based on the mail agent.