### PR TITLE
Add option to export ASCII for text/plain section

### DIFF
--- a/README.org
+++ b/README.org
@@ -127,6 +127,25 @@ Thibault Marin provided [[https://lists.gnu.org/archive/html/emacs-orgmode/2019-
           (search-forward "<#secure method=pgpmime mode=sign>")
           (+ (point) 1))))
 #+end_src
+** ASCII export options for text/plain
+Use =org-mime-export-ascii= to export the org-mode file as ASCII for the
+=text/plain= section of the email message. The default is to export the
+original unmodified org-mode file.
+
+ASCII export options:
+- plain text
+    #+begin_src elisp
+(setq org-mime-export-ascii 'ascii)
+    #+end_src
+- latin1
+    #+begin_src elisp
+(setq org-mime-export-ascii 'latin1)
+    #+end_src
+- utf-8
+    #+begin_src elisp
+(setq org-mime-export-ascii 'utf-8)
+    #+end_src
+
 * Development
 - Patches are always welcomed
 - You can =(setq org-mime-debug t)= to enable the log

--- a/org-mime.el
+++ b/org-mime.el
@@ -204,14 +204,14 @@ buffer holding the text to be exported.")
   "Similar to `org-html-export-as-html' and `org-org-export-as-org'.
 SUBTREEP is t if current node is subtree."
   (let* (
-         (plain
-          (cl-case org-mime-export-ascii
-            (ascii (org-export-string-as (buffer-string) 'ascii nil '(:ascii-charset ascii)))
-            (latin1 (org-export-string-as (buffer-string) 'ascii nil '(:ascii-charset latin1)))
-            (utf-8 (org-export-string-as (buffer-string) 'ascii nil '(:ascii-charset utf-8)))
-            (t (buffer-string)) ;; default is the original org file
-           )
-          )
+         (plain (cl-case org-mime-export-ascii
+                  (ascii (org-export-string-as (buffer-string)
+                           'ascii nil '(:ascii-charset ascii)))
+                  (latin1 (org-export-string-as (buffer-string)
+                            'ascii nil '(:ascii-charset latin1)))
+                  (utf-8 (org-export-string-as (buffer-string)
+                           'ascii nil '(:ascii-charset utf-8)))
+                  (t (buffer-string)))) ;; original org file
          (buf (org-export-to-buffer 'html "*Org Mime Export*"
                 nil subtreep nil (org-mime-get-export-options subtreep)))
          (body (prog1
@@ -307,7 +307,7 @@ If html portion of message includes IMAGES they are wrapped in multipart/related
     (mml (concat "<#multipart type=alternative>\n<#part type=text/plain>\n"
                  plain
                  (when images "<#multipart type=related>")
-                 "<#part type=text/html>"
+                 "<#part type=text/html>\n"
                  (if org-mime-beautify-quoted-mail
                      (org-mime-beautify-quoted html)
                    html)


### PR DESCRIPTION
Add an option to export plain text, latin1, or utf-8 ASCII for the
text/plain section in the outgoing email message. The default is to use
the original org-mode file.