### PR TITLE
Fix ASCII org-mime-htmlize output (#36)

### DIFF
--- a/org-mime.el
+++ b/org-mime.el
@@ -449,7 +449,7 @@ If called with an active region only export that region, otherwise entire body."
          (plain (if ascii-charset
                     (progn
                       (setq org-ascii-charset ascii-charset)
-                      (org-export-string-as (buffer-string) 'ascii nil opts))
+                      (org-export-string-as (concat org-mime-default-header org-text) 'ascii nil opts))
                   org-text))
          (html (org-mime-export-string (concat org-mime-default-header org-text) opts))
          (file (make-temp-name (expand-file-name


### PR DESCRIPTION
- ASCII export for org-mime-htmlize should not use the entire buffer.
- Include org-mime-default-header to be more like the HTML export.