### PR TITLE
Improve signature separator regex

### DIFF
--- a/org-mime.el
+++ b/org-mime.el
@@ -166,7 +166,7 @@ Default (nil) selects the original org-mode file."
   :group 'org-mime
   :type 'sexp)
 
-(defcustom org-mime-mail-signature-separator "^--"
+(defcustom org-mime-mail-signature-separator "^--\s?$"
   "Default mail signature separator."
   :group 'org-mime
   :type 'string)


### PR DESCRIPTION
The original signature separator regex may have inadvertantly caught [MIME part boundaries](https://stackoverflow.com/questions/28381782/what-are-in-email-headers) in addition to the signature separator `-- \n`