### PR TITLE
Show individual paragraphs in gmail reply quotes

### DIFF
--- a/org-mime.el
+++ b/org-mime.el
@@ -324,8 +324,7 @@ HTML is the body of the message."
             (progn
               (insert "</div>\n<div>")
               (forward-line)
-              (insert "<br />")
-              (insert "</div>\n<div>"))
+              (insert "<br /></div>\n<div>"))
           (forward-line)))
       (buffer-substring (point-min) (point-max)))))
 

--- a/test/org-mime-tests.el
+++ b/test/org-mime-tests.el
@@ -245,4 +245,35 @@
       (should-not (string-match "SECTION_ONE" str)))
     (kill-buffer orgBuf)))
 
+(ert-deftest test-org-mime-beautify-quoted-para-breaks ()
+    (setq html (concat "<p>\n"
+                       "Hello there\n"
+                       "</p>\n"
+                       "\n"
+                       "<p>\n"
+                       "&gt; this is a long-ish para that is broken\n"
+                       "&gt; on two lines\n"
+                       "&gt;\n"
+                       "&gt; followed by a single-line para\n"
+                       "</p>\n"))
+    (setq expected (concat "<p>\n"
+                           "Hello there\n"
+                           "</p>\n"
+                           "\n"
+                           "<p>\n"
+                           "<blockquote class=\"gmail_quote\" style=\"margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex\">\n"
+                           "\n"
+                           "<div>this is a long-ish para that is broken\n"
+                           "on two lines\n"
+                           "</div>\n"
+                           "<div>\n"
+                           "<br /></div>\n"
+                           "<div>followed by a single-line para\n"
+                           "\n"
+                           "</div></blockquote>\n"
+                           "</p>\n"))
+    (setq beautified (org-mime-beautify-quoted html))
+    (should (equal beautified expected))
+)
+
 (ert-run-tests-batch-and-exit)


### PR DESCRIPTION
Prior to this patch, replies using the org-mime-beautify-quoted-mail option
would show up with multiple paragraphs in the reply squashed onto a single
line (at least in gmail).

For example, the reply:

```
> This is one para (which is
> split across two lines)
>
> This is another
```

Would get rendered as:

```
<p>
This is one para (which is
split across two lines)

This is another
</p>
```

And displayed in gmail as:

```
| This is one para (which is split across two lines) This is another
```

(Where '|' is the beautifed vertical line in gmail.)

Looking at how gmail itself deals with multiple paras in a reply, it appears
they:

1. put each paragraph in its own div
2. represent blank lines between divs as <br />

They do some funky nesting that doesn't seem to be needed to make the quotes
display correctly, so I've left it out.

This patch would render the example above into the structure:

```
<div>This is one para (which is
split across two lines)</div>
<div><br/></div>
<div>This is another</div>
```

(With some less beautiful line breaks) and displayed in gmail as:

```
| This is one para (which is split across two lines)
|
| This is another
```

To better represent the gmail de-factor standard, this patch also changes the
top-level element in the gmail blockquote to div (from p).