### PR TITLE
Clean up name of test file in comment

### DIFF
--- a/test/org-mime-tests.el
+++ b/test/org-mime-tests.el
@@ -1,4 +1,4 @@
-;; counsel-etags-tests.el --- unit tests for counsel-etags -*- coding: utf-8 -*-
+;; org-mime-tests.el --- unit tests for org-mime -*- coding: utf-8 -*-
 
 ;; Author: Chen Bin <chenbin DOT sh AT gmail DOT com>
 


### PR DESCRIPTION
While I was writing a unit test for the other branch I happened to notice the name of the test file mismatches the comment.