### PR TITLE
Add NonGNU ELPA badge

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,5 +1,6 @@
 * org-mime
 [[https://travis-ci.org/org-mime/org-mime][https://travis-ci.org/org-mime/org-mime.svg?branch=master]]
+[[https://elpa.nongnu.org/nongnu/org-mime.html][https://elpa.nongnu.org/nongnu/org-mime.svg]]
 [[http://melpa.org/#/org-mime][file:http://melpa.org/packages/org-mime-badge.svg]] [[http://stable.melpa.org/#/org-mime][file:http://stable.melpa.org/packages/org-mime-badge.svg]]
 
 This program sends HTML email using Org-mode HTML export.


### PR DESCRIPTION
This package is now on NonGNU ELPA!

This commit adds a NonGNU ELPA badge to the README, because it looks nice and is occasionally useful. It also updates the installation instructions.

Thanks!