### PR TITLE
Added support for In-Reply-To header

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,7 +50,7 @@ The following key bindings are suggested, which bind the C-c M-o key sequence to
 ** =M-x org-mime-org-subtree-htmlize=
 =org-mime-org-subtree-htmlize= is similar to =org-mime-org-buffer-htmlize=
 but works on subtree. It can also read subtree properties MAIL_SUBJECT,
-MAIL_TO, MAIL_CC, and MAIL_BCC. Here is the sample of subtree:
+MAIL_TO, MAIL_CC, MAIL_BCC, and MAIL_IN_REPLY_TO. Here is the sample of subtree:
 #+begin_example
  * mail one
   :PROPERTIES:
@@ -58,6 +58,7 @@ MAIL_TO, MAIL_CC, and MAIL_BCC. Here is the sample of subtree:
   :MAIL_TO: person1@gmail.com
   :MAIL_CC: person2@gmail.com
   :MAIL_BCC: person3@gmail.com
+  :MAIL_IN_REPLY_TO: <MESSAGE-ID>
   :END:
  some text here ...
 #+end_example


### PR DESCRIPTION
In response to #85 this adds support for the In-Reply-To header.

This allows you to leverage a capture template when reading an email in something like mu4e so that your response to an email thread is associated with the appropriate previous message.

Here is an example capture template (this one is for org-roam)

```emacs-lisp
("er" "Response" entry
 "* Respond to %:from: %:subject :email:\n:properties:\n:mail_from: Me <my.org>\n:mail_to: %:fromaddress\n:MAIL_IN_REPLY_TO: <%:message-id>\n:end:\n%a\n#+begin_quote\n   %i\n#+end_quote\n\n%?"
 :if-new (file+head ,(expand-file-name "email/%<%Y-%m-%d>.org" org-roam-dailies-directory)
                    "#+title: Email for %<%Y-%m-%d>")
 :clock-in t
 :clock-resume t
 )
```

In org-mode the capture would look something like this:

```org
* Respond to Me <person@some.place>: Respond to Me <me@my.org>: Testing reply to header :email:
:properties:
:mail_from: Me <me@my.org>
:mail_to: person@some.place
:MAIL_IN_REPLY_TO: <87edph4zts.fsf@some.place>
:CREATED:  [2023-03-21 Tue 15:32]
:ID:       11076b0a-4cda-4e03-a2c5-a37c7eceb4d3
:end:
:LOGBOOK:
CLOCK: [2023-03-21 Tue 15:32]--[2023-03-21 Tue 15:32] =>  0:00
:END:
[[mu4e:msgid:87edph4zts.fsf@some.place][Respond to Me <me@my.org>: Testing reply to header]]
#+begin_quote

   Testing reply to header

    testing

   Yep


#+end_quote

More to repsond make a thread
```

Then when running `org-mime-htmlize` (here `org-mime-htmlize-subtree` was used) you get an email prepared with the proper In-Reply-To header.

```message
From: Me <me@my.org>
To: person@some.place
Subject: Respond to Me <person@some.place>: Respond to Me <me@my.org>: Testing reply to header
In-Reply-To: <87edph4zts.fsf@some.place>
--text follows this line--
<#multipart type=alternative>
<#part type=text/plain>
Respond to Me <person@some.place>: Respond to Me <me@my.org>: Testing reply to header :email:
==========================================================================================================================

  [Respond to Me <me@my.org>: Testing reply
  to header]


        Testing reply to header

        testing

        Yep

  More to repsond make a thread

```